### PR TITLE
Rename package from signals to petesignals

### DIFF
--- a/src/petesignals/Signal.hx
+++ b/src/petesignals/Signal.hx
@@ -11,7 +11,7 @@ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TOR
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-package signal;
+package petesignals;
 
 import haxe.extern.EitherType;
 /**

--- a/src/petesignals/Signal1.hx
+++ b/src/petesignals/Signal1.hx
@@ -1,6 +1,6 @@
-package signal;
+package petesignals;
 
-import signal.Signal.BaseSignal;
+import petesignals.Signal.BaseSignal;
 
 class Signal1<T> extends BaseSignal<(T) -> Void>
 {

--- a/src/petesignals/Signal2.hx
+++ b/src/petesignals/Signal2.hx
@@ -1,6 +1,6 @@
-package signal;
+package petesignals;
 
-import signal.Signal.BaseSignal;
+import petesignals.Signal.BaseSignal;
 
 class Signal2<T, K> extends BaseSignal<(T, K) -> Void>
 {


### PR DESCRIPTION
Hello,
Yesterday I started to use your signals library in my projects but my CI started failing to build on OSX with hxcpp. Looking into it it seems the `signals` namespace is already used in the OSX api and hxcpp is redefining it by converting this libraries package into a c++ namespace.

```
Error: In file included from ./src/uk/aidanlee/flurry/api/resources/ResourceSystem.cpp:71:
include/signal/BaseSignal.h:10:19: error: redefinition of 'signal' as different kind of symbol
HX_DECLARE_CLASS1(signal,BaseSignal)
                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include/sys/signal.h:390:8: note: previous definition is here
void    (*signal(int, void (*)(int)))(int);
          ^
In file included from ./src/uk/aidanlee/flurry/api/resources/ResourceSystem.cpp:71:
include/signal/BaseSignal.h:12:11: error: redefinition of 'signal' as different kind of symbol
namespace signal{
          ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include/sys/signal.h:390:8: note: previous definition is here
void    (*signal(int, void (*)(int)))(int);
          ^
```
I've renamed the package from `signals` to `petesignals` in my fork and everything's now compiling fine on OSX. Not sure if you'd want to use a different package name but it got the job done and I thought I'd bring it up in case anyone else runs into issues!