### PR TITLE
Expand functionality, adopt haxe 4 function notation, workaround recent regression

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"tags": ["signal", "signals", "events"],
 	"description": "A simple and super light weight event system replacement.",
-	"version": "1.2.7",
+	"version": "1.3.0",
 	"releasenote": "Allow callback with varying signatures",
 	"contributors": [ "p.j.shand" ],
 	"classPath": "src"

--- a/src/signal/Signal3.hx
+++ b/src/signal/Signal3.hx
@@ -1,0 +1,12 @@
+package signal;
+
+/*
+ * Due to incompatibilities with the CPP Mac target the
+ * "signal" package has been deprecated in favour of "signals",
+ *
+ * Warning: The "signal" package will be removed in a future release, it is recommended
+ * to switch to the "signals" package to avoid future incompatibility issues.
+ */
+import signals.Signal3 as Signal3_;
+
+@:deprecated typedef Signal3<T, K, I> = Signal3_<T, K, I>;

--- a/src/signals/Signal.hx
+++ b/src/signals/Signal.hx
@@ -74,7 +74,7 @@ class BaseSignal<Callback> {
 	var toTrigger:Array<SignalCallbackData> = [];
 	var requiresSort:Bool = false;
 
-	var valience:Int = 0;
+	var valence:Int = 0;
 
 	public function new(?fireOnAdd:Bool = false) {
 		this._fireOnAdd = fireOnAdd;
@@ -206,41 +206,13 @@ class BaseSignal<Callback> {
 	}
 
 	function getNumParams(callback:Callback):Int {
+		#if(!static)
 		var length:Null<Int> = Reflect.getProperty(callback, 'length');
 		if (length != null) {
 			return length;
-		} else {
-			return this.valience;
-			//throw "length not supported";
 		}
-		/*
-			var c0:Void->Void = () -> {};
-			var c1:Dynamic->Void = (d:Dynamic) -> {};
-			var c2:Dynamic->Dynamic->Void = (d1:Dynamic, d2:Dynamic) -> {};
-
-			trace(c0 == untyped callback);
-			trace(c1 == untyped callback);
-			trace(c2 == untyped callback);
-			try {
-				c2 = untyped callback;
-			} catch (e:Dynamic) {
-				try {
-					c1 = untyped callback;
-				} catch (e:Dynamic) {
-					try {
-						c0 = untyped callback;
-					} catch (e:Dynamic) {}
-				}
-			}
-			if (c0 != null)
-				return 0;
-			else if (c1 != null)
-				return 1;
-			else if (c2 != null)
-				return 2;
-			else
-				return -1;
-		 */
+		#end
+		return this.valence;
 	}
 
 	/**

--- a/src/signals/Signal.hx
+++ b/src/signals/Signal.hx
@@ -19,7 +19,8 @@ import haxe.extern.EitherType;
  *  The API is based off massiveinteractive's msignal and Robert Penner’s AS3 Signals, however is greatly simplified.
  */
 @:expose("Signal")
-class Signal extends BaseSignal<Void->Void> {
+class Signal extends BaseSignal<()->Void> {
+
 	public function new(?fireOnAdd:Bool = false) {
 		super(fireOnAdd);
 	}
@@ -29,19 +30,19 @@ class Signal extends BaseSignal<Void->Void> {
 		dispatchCallbacks();
 	}
 
-	override function dispatchCallback(callback:Void->Void) {
+	override function dispatchCallback(callback:()->Void) {
 		callback();
 	}
 
-	override function dispatchCallback1(callback:Dynamic->Void) {
+	override function dispatchCallback1(callback:(Dynamic)->Void) {
 		throw "Use Signal 1";
 	}
 
-	override function dispatchCallback2(callback:Dynamic->Dynamic->Void) {
+	override function dispatchCallback2(callback:(Dynamic, Dynamic)->Void) {
 		throw "Use Signal 2";
 	}
 
-	override function dispatchCallback3(callback:Dynamic->Dynamic->Dynamic->Void) {
+	override function dispatchCallback3(callback:(Dynamic, Dynamic, Dynamic)->Void) {
 		throw "Use Signal 3";
 	}
 }
@@ -72,6 +73,8 @@ class BaseSignal<Callback> {
 	var callbacks:Array<SignalCallbackData> = [];
 	var toTrigger:Array<SignalCallbackData> = [];
 	var requiresSort:Bool = false;
+
+	var valience:Int = 0;
 
 	public function new(?fireOnAdd:Bool = false) {
 		this._fireOnAdd = fireOnAdd;
@@ -115,19 +118,19 @@ class BaseSignal<Callback> {
 		toTrigger = [];
 	}
 
-	function dispatchCallback(callback:Void->Void) {
+	function dispatchCallback(callback:()->Void) {
 		throw "implement in override";
 	}
 
-	function dispatchCallback1(callback:Dynamic->Void) {
+	function dispatchCallback1(callback:(Dynamic)->Void) {
 		throw "implement in override";
 	}
 
-	function dispatchCallback2(callback:Dynamic->Dynamic->Void) {
+	function dispatchCallback2(callback:(Dynamic, Dynamic)->Void) {
 		throw "implement in override";
 	}
 
-	function dispatchCallback3(callback:Dynamic->Dynamic->Dynamic->Void) {
+	function dispatchCallback3(callback:(Dynamic, Dynamic, Dynamic)->Void) {
 		throw "implement in override";
 	}
 
@@ -207,7 +210,8 @@ class BaseSignal<Callback> {
 		if (length != null) {
 			return length;
 		} else {
-			throw "length not supported";
+			return this.valience;
+			//throw "length not supported";
 		}
 		/*
 			var c0:Void->Void = () -> {};
@@ -304,7 +308,7 @@ typedef SignalCallbackData = {
 	repeat:Int,
 	priority:Int,
 	remove:Bool,
-	?dispatchMethod:Dynamic->Void
+	?dispatchMethod:(Dynamic)->Void
 }
 
 typedef Signal0 = Signal

--- a/src/signals/Signal.hx
+++ b/src/signals/Signal.hx
@@ -40,6 +40,10 @@ class Signal extends BaseSignal<Void->Void> {
 	override function dispatchCallback2(callback:Dynamic->Dynamic->Void) {
 		throw "Use Signal 2";
 	}
+
+	override function dispatchCallback3(callback:Dynamic->Dynamic->Dynamic->Void) {
+		throw "Use Signal 3";
+	}
 }
 
 @:expose("BaseSignal")
@@ -123,6 +127,10 @@ class BaseSignal<Callback> {
 		throw "implement in override";
 	}
 
+	function dispatchCallback3(callback:Dynamic->Dynamic->Dynamic->Void) {
+		throw "implement in override";
+	}
+
 	function sortCallbacks(s1:SignalCallbackData, s2:SignalCallbackData):Int {
 		if (s1.priority > s2.priority)
 			return -1;
@@ -178,6 +186,8 @@ class BaseSignal<Callback> {
 			currentCallback.dispatchMethod = dispatchCallback1;
 		} else if (numParams == 2) {
 			currentCallback.dispatchMethod = dispatchCallback2;
+		} else if(numParams == 3){
+			currentCallback.dispatchMethod = dispatchCallback3;
 		}
 
 		callbacks.push(currentCallback);

--- a/src/signals/Signal1.hx
+++ b/src/signals/Signal1.hx
@@ -27,6 +27,10 @@ class Signal1<T> extends BaseSignal<Func0or1<T>> {
 	override function dispatchCallback2(callback:Dynamic->Dynamic->Void) {
 		throw "Use Signal 2";
 	}
+
+	override function dispatchCallback3(callback:Dynamic->Dynamic->Dynamic->Void) {
+		throw "Use Signal 3";
+	}
 }
 
 // Void->Void // T->Void

--- a/src/signals/Signal1.hx
+++ b/src/signals/Signal1.hx
@@ -3,11 +3,16 @@ package signals;
 import haxe.extern.EitherType;
 import signals.Signal.BaseSignal;
 
-typedef Func0or1<T> = EitherType<Void->Void, T->Void>;
+typedef Func0or1<T> = EitherType<()->Void, (T)->Void>;
 
 @:expose("Signal1")
 class Signal1<T> extends BaseSignal<Func0or1<T>> {
 	public var value:T;
+
+	override public function new(){
+		super();
+		this.valience = 1;
+	}
 
 	public function dispatch(value1:T) {
 		sortPriority();
@@ -16,19 +21,19 @@ class Signal1<T> extends BaseSignal<Func0or1<T>> {
 		value = null;
 	}
 
-	override function dispatchCallback(callback:Void->Void) {
+	override function dispatchCallback(callback:()->Void) {
 		callback();
 	}
 
-	override function dispatchCallback1(callback:Dynamic->Void) {
+	override function dispatchCallback1(callback:(Dynamic)->Void) {
 		callback(value);
 	}
 
-	override function dispatchCallback2(callback:Dynamic->Dynamic->Void) {
+	override function dispatchCallback2(callback:(Dynamic,Dynamic)->Void) {
 		throw "Use Signal 2";
 	}
 
-	override function dispatchCallback3(callback:Dynamic->Dynamic->Dynamic->Void) {
+	override function dispatchCallback3(callback:(Dynamic, Dynamic, Dynamic)->Void) {
 		throw "Use Signal 3";
 	}
 }

--- a/src/signals/Signal1.hx
+++ b/src/signals/Signal1.hx
@@ -11,7 +11,7 @@ class Signal1<T> extends BaseSignal<Func0or1<T>> {
 
 	override public function new(){
 		super();
-		this.valience = 1;
+		this.valence = 1;
 	}
 
 	public function dispatch(value1:T) {

--- a/src/signals/Signal2.hx
+++ b/src/signals/Signal2.hx
@@ -3,9 +3,14 @@ package signals;
 import signals.Signal.BaseSignal;
 
 @:expose("Signal2")
-class Signal2<T, K> extends BaseSignal<T->K->Void> {
+class Signal2<T, K> extends BaseSignal<(T,K)->Void> {
 	public var value1:T;
 	public var value2:K;
+
+	override public function new(){
+		super();
+		this.valience = 2;
+	}
 
 	public function dispatch(value1:T, value2:K) {
 		sortPriority();
@@ -16,19 +21,19 @@ class Signal2<T, K> extends BaseSignal<T->K->Void> {
 		value2 = null;
 	}
 
-	override function dispatchCallback(callback:Void->Void) {
+	override function dispatchCallback(callback:()->Void) {
 		callback();
 	}
 
-	override function dispatchCallback1(callback:T->Void) {
+	override function dispatchCallback1(callback:(T)->Void) {
 		callback(value1);
 	}
 
-	override function dispatchCallback2(callback:T->K->Void) {
+	override function dispatchCallback2(callback:(T,K)->Void) {
 		callback(value1, value2);
 	}
 
-	override function dispatchCallback3(callback:Dynamic->Dynamic->Dynamic->Void) {
+	override function dispatchCallback3(callback:(Dynamic,Dynamic,Dynamic)->Void) {
 		throw "Use Signal 3";
 	}
 }

--- a/src/signals/Signal2.hx
+++ b/src/signals/Signal2.hx
@@ -9,7 +9,7 @@ class Signal2<T, K> extends BaseSignal<(T,K)->Void> {
 
 	override public function new(){
 		super();
-		this.valience = 2;
+		this.valence = 2;
 	}
 
 	public function dispatch(value1:T, value2:K) {

--- a/src/signals/Signal3.hx
+++ b/src/signals/Signal3.hx
@@ -2,18 +2,21 @@ package signals;
 
 import signals.Signal.BaseSignal;
 
-@:expose("Signal2")
-class Signal2<T, K> extends BaseSignal<T->K->Void> {
+@:expose("Signal3")
+class Signal3<T, K, I> extends BaseSignal<T->K->I->Void> {
 	public var value1:T;
 	public var value2:K;
+	public var value3:I;
 
-	public function dispatch(value1:T, value2:K) {
+	public function dispatch(value1:T, value2:K, value3:I) {
 		sortPriority();
 		this.value1 = value1;
 		this.value2 = value2;
+		this.value3 = value3;
 		dispatchCallbacks();
 		value1 = null;
 		value2 = null;
+		value3 = null;
 	}
 
 	override function dispatchCallback(callback:Void->Void) {
@@ -28,7 +31,7 @@ class Signal2<T, K> extends BaseSignal<T->K->Void> {
 		callback(value1, value2);
 	}
 
-	override function dispatchCallback3(callback:Dynamic->Dynamic->Dynamic->Void) {
-		throw "Use Signal 3";
+	override function dispatchCallback3(callback:T->K->I->Void) {
+		callback(value1, value2, value3);
 	}
 }

--- a/src/signals/Signal3.hx
+++ b/src/signals/Signal3.hx
@@ -10,7 +10,7 @@ class Signal3<T, K, I> extends BaseSignal<(T,K,I)->Void> {
 
 	override public function new(){
 		super();
-		this.valience = 3;
+		this.valence = 3;
 	}
 
 	public function dispatch(value1:T, value2:K, value3:I) {

--- a/src/signals/Signal3.hx
+++ b/src/signals/Signal3.hx
@@ -3,10 +3,15 @@ package signals;
 import signals.Signal.BaseSignal;
 
 @:expose("Signal3")
-class Signal3<T, K, I> extends BaseSignal<T->K->I->Void> {
+class Signal3<T, K, I> extends BaseSignal<(T,K,I)->Void> {
 	public var value1:T;
 	public var value2:K;
 	public var value3:I;
+
+	override public function new(){
+		super();
+		this.valience = 3;
+	}
 
 	public function dispatch(value1:T, value2:K, value3:I) {
 		sortPriority();
@@ -19,19 +24,19 @@ class Signal3<T, K, I> extends BaseSignal<T->K->I->Void> {
 		value3 = null;
 	}
 
-	override function dispatchCallback(callback:Void->Void) {
+	override function dispatchCallback(callback:()->Void) {
 		callback();
 	}
 
-	override function dispatchCallback1(callback:T->Void) {
+	override function dispatchCallback1(callback:(T)->Void) {
 		callback(value1);
 	}
 
-	override function dispatchCallback2(callback:T->K->Void) {
+	override function dispatchCallback2(callback:(T,K)->Void) {
 		callback(value1, value2);
 	}
 
-	override function dispatchCallback3(callback:T->K->I->Void) {
+	override function dispatchCallback3(callback:(T,K,I)->Void) {
 		callback(value1, value2, value3);
 	}
 }


### PR DESCRIPTION
It seems 6a4949f4f6ed4733f2586642300d682016b6db2e broke Signals on static targets. Specifically, https://github.com/peteshand/signals/blob/master/src/signals/Signal.hx#L196 will always return `null` on Neko and Windows, resulting in all calls to `add()` throwing an exception. 

This PR contains
- Addition of Signal3, because Signal2 never quite seemed like enough :^)
- Change of all function signatures to reflect haxe4 standard `(Foo, Bar)->Baz`
- Addition of `valence` so that `Reflect.getProperty(callback, 'length')` has something to fall back on when it fails on static targets

I realise this means that static targets implicitly don't support the features added in 6a4949f4f6ed4733f2586642300d682016b6db2e, but I wasn't using them anyway and surely this is better than Signals just crashing your program. 

I do question whether calling `Reflect` on every `add` is really worth the overhead on a library that sells itself on performance, though.

I would love if there were a better, more unified way to get the function argument count at runtime, but I haven't been able to find one.