### PR TITLE
Cover failure cases properly 

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"tags": ["signal", "signals", "events"],
 	"description": "A simple and super light weight event system replacement.",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"releasenote": "Allow callback with varying signatures",
 	"contributors": [ "p.j.shand" ],
 	"classPath": "src"

--- a/src/signals/Signal.hx
+++ b/src/signals/Signal.hx
@@ -206,7 +206,7 @@ class BaseSignal<Callback> {
 	}
 
 	function getNumParams(callback:Callback):Int {
-		#if(!static)
+		#if(flash||js)
 		var length:Null<Int> = Reflect.getProperty(callback, 'length');
 		if (length != null) {
 			return length;


### PR DESCRIPTION
Given the discussion on #5, this changes the compile flag to ensure it doesn't *fail* on any target.

Just a stopgap until #6 is implemented.